### PR TITLE
AS: Add basic compile testing

### DIFF
--- a/.github/workflows/basic.yml
+++ b/.github/workflows/basic.yml
@@ -1,0 +1,49 @@
+name: attestation-service basic build and unit tests
+on: [push, pull_request, create]
+
+jobs:
+  basic_ci:
+    if: github.event_name == 'pull_request' || github.event_name == 'push'
+    name: Check
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        rust:
+          - stable
+    steps:
+      - name: Code checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+
+      - name: Install Rust toolchain (${{ matrix.rust }})
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.rust }}
+          override: true
+          components: rustfmt, clippy
+
+      - name: Run cargo build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release
+
+      - name: Run cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+
+      - name: Run cargo fmt check
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+
+      - name: Run rust lint check
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: -- -D warnings

--- a/lib/src/core/mod.rs
+++ b/lib/src/core/mod.rs
@@ -59,7 +59,7 @@ pub struct Attestation {}
 impl Attestation {
     pub async fn evaluate(
         &self,
-        evidence: &String,
+        evidence: &str,
         policy: Option<String>,
         reference_data: Option<String>,
     ) -> Result<String> {

--- a/lib/src/core/verifier/policy/opa/mod.rs
+++ b/lib/src/core/verifier/policy/opa/mod.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, Result};
 use std::ffi::CStr;
 use std::os::raw::c_char;
 
-/// Link import cgo function
+// Link import cgo function
 #[link(name = "opa")]
 extern "C" {
     pub fn evaluateGo(policy: GoString, data: GoString, input: GoString) -> *mut c_char;
@@ -46,7 +46,7 @@ pub fn evaluate(policy: String, reference: String, input: String) -> Result<Stri
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde_json::{Result, Value, json};
+    use serde_json::{json, Result, Value};
 
     fn dummy_policy() -> Result<String> {
         let policy = r#"
@@ -102,36 +102,29 @@ svn_old_allow {
     fn test_evaluate() {
         let policy = dummy_policy().unwrap();
 
-        let res = evaluate(
-            policy.clone(), 
-            dummy_reference(3), 
-            dummy_input(5, 5)
-        );
-        assert!(res.is_ok(), "OPA execution() should success");
+        let res = evaluate(policy.clone(), dummy_reference(3), dummy_input(5, 5));
+        assert!(res.is_ok(), "OPA execution() should be success");
         let v: Value = serde_json::from_str(&res.unwrap()).unwrap();
-        assert!(v["allow"] == true, "allow should true");
-        assert!(v["product_id_allow"] == true, "product_id_allow should true");
-        assert!(v["svn_allow"] == true, "svn_allow should true");
-
-
-        let res = evaluate(
-            policy.clone(), 
-            dummy_reference(3), 
-            dummy_input(5, 2)
+        assert!(v["allow"] == true, "allow should be true");
+        assert!(
+            v["product_id_allow"] == true,
+            "product_id_allow should be true"
         );
-        assert!(res.is_ok(), "OPA execution() should success");
-        let v: Value = serde_json::from_str(&res.unwrap()).unwrap();
-        assert!(v["allow"] == true, "allow should true");
-        assert!(v["product_id_allow"] == true, "product_id_allow should true");
-        assert!(v["svn_old_allow"] == true, "svn_old_allow should true");
+        assert!(v["svn_allow"] == true, "svn_allow should be true");
 
-        let res = evaluate(
-            policy.clone(), 
-            dummy_reference(5), 
-            dummy_input(0, 0)
-        );
-        assert!(res.is_ok(), "OPA execution() should success");
+        let res = evaluate(policy.clone(), dummy_reference(3), dummy_input(5, 2));
+        assert!(res.is_ok(), "OPA execution() should be success");
         let v: Value = serde_json::from_str(&res.unwrap()).unwrap();
-        assert!(v["allow"] == false, "allow should false");
+        assert!(v["allow"] == true, "allow should be true");
+        assert!(
+            v["product_id_allow"] == true,
+            "product_id_allow should be true"
+        );
+        assert!(v["svn_old_allow"] == true, "svn_old_allow should be true");
+
+        let res = evaluate(policy.clone(), dummy_reference(5), dummy_input(0, 0));
+        assert!(res.is_ok(), "OPA execution() should be success");
+        let v: Value = serde_json::from_str(&res.unwrap()).unwrap();
+        assert!(v["allow"] == false, "allow should be false");
     }
 }

--- a/lib/src/core/verifier/sample/mod.rs
+++ b/lib/src/core/verifier/sample/mod.rs
@@ -3,12 +3,12 @@ extern crate serde;
 use self::serde::{Deserialize, Serialize};
 use super::*;
 use crate::core::verifier::policy::opa;
+use crate::default_policy;
+use crate::default_reference_data;
 use async_trait::async_trait;
 use base64;
 use serde_json::{json, Value};
 use sha2::{Digest, Sha384};
-use crate::default_policy;
-use crate::default_reference_data;
 
 #[derive(Serialize, Deserialize, Debug)]
 struct Ehd {
@@ -55,11 +55,11 @@ impl Verifier for Sample {
         reference_data: Option<String>,
     ) -> Result<AttestationResults> {
         // Use the default policy/reference_data if the input is None.
-        let policy = policy.unwrap_or(std::include_str!(default_policy!()).to_string());
-        let reference_data =
-            reference_data.unwrap_or(std::include_str!(default_reference_data!()).to_string());
+        let policy = policy.unwrap_or_else(|| std::include_str!(default_policy!()).to_string());
+        let reference_data = reference_data
+            .unwrap_or_else(|| std::include_str!(default_reference_data!()).to_string());
 
-        verify(&evidence)
+        verify(evidence)
             .await
             .context("Evidence's identity verification error.")?;
 
@@ -96,7 +96,7 @@ impl Verifier for Sample {
 }
 
 // Demo to fetch the TCB status from the quote
-fn tcb_status(quote: &String) -> Result<Tcb> {
+fn tcb_status(quote: &str) -> Result<Tcb> {
     debug!("Quote<sample>: {}", &quote);
     let q = serde_json::from_str::<Quote>(quote).context("Deserialize Quote failed.")?;
     Ok(Tcb {

--- a/lib/src/core/verifier/sgx/mod.rs
+++ b/lib/src/core/verifier/sgx/mod.rs
@@ -1,8 +1,8 @@
-use anyhow::{anyhow, Result};
 use super::*;
-use async_trait::async_trait;
 use crate::default_policy;
 use crate::default_reference_data;
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
 
 #[derive(Debug, Default)]
 pub struct Sgx {}
@@ -16,9 +16,9 @@ impl Verifier for Sgx {
         reference_data: Option<String>,
     ) -> Result<AttestationResults> {
         // Use the default policy/reference_data if the input is None.
-        let _policy = policy.unwrap_or(std::include_str!(default_policy!()).to_string());
-        let _reference_data =
-            reference_data.unwrap_or(std::include_str!(default_reference_data!()).to_string());
+        let _policy = policy.unwrap_or_else(|| std::include_str!(default_policy!()).to_string());
+        let _reference_data = reference_data
+            .unwrap_or_else(|| std::include_str!(default_reference_data!()).to_string());
 
         Err(anyhow!("not implemented!"))
     }

--- a/lib/src/core/verifier/tdx/mod.rs
+++ b/lib/src/core/verifier/tdx/mod.rs
@@ -1,8 +1,8 @@
-use anyhow::{anyhow, Result};
 use super::*;
-use async_trait::async_trait;
 use crate::default_policy;
 use crate::default_reference_data;
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
 
 #[derive(Debug, Default)]
 pub struct Tdx {}
@@ -16,9 +16,9 @@ impl Verifier for Tdx {
         reference_data: Option<String>,
     ) -> Result<AttestationResults> {
         // Use the default policy/reference_data if the input is None.
-        let _policy = policy.unwrap_or(std::include_str!(default_policy!()).to_string());
-        let _reference_data =
-            reference_data.unwrap_or(std::include_str!(default_reference_data!()).to_string());
+        let _policy = policy.unwrap_or_else(|| std::include_str!(default_policy!()).to_string());
+        let _reference_data = reference_data
+            .unwrap_or_else(|| std::include_str!(default_reference_data!()).to_string());
 
         Err(anyhow!("not implemented!"))
     }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -117,7 +117,7 @@ impl Service {
     /// ```
     pub async fn attestation(
         &self,
-        evidence: &String,
+        evidence: &str,
         policy: Option<String>,
         reference_data: Option<String>,
     ) -> Result<String> {


### PR DESCRIPTION
1.Enable the basic compile check for AS.
2.Fixed some warning errors that were detected by the `cargo fmt --all -- --check` and `cargo clippy -- -D warnings`.

Fixes: #5
Signed-off-by: zhouliang121 <liang.a.zhou@linux.alibaba.com>