### PR TITLE
Allow "clippy::derive_partial_eq_without_eq" for autogenerated code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+target/
+Cargo.lock

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -10,12 +10,18 @@ use tokio::sync::RwLock;
 extern crate lazy_static;
 
 pub mod management_api {
+    #![allow(unknown_lints)]
+    #![allow(clippy::derive_partial_eq_without_eq)]
     tonic::include_proto!("management");
 }
 pub mod attestation_api {
+    #![allow(unknown_lints)]
+    #![allow(clippy::derive_partial_eq_without_eq)]
     tonic::include_proto!("attestation");
 }
 pub mod common {
+    #![allow(unknown_lints)]
+    #![allow(clippy::derive_partial_eq_without_eq)]
     tonic::include_proto!("common");
 }
 


### PR DESCRIPTION
This is a recommendation given by the maintainer of the prost crate.
See: tokio-rs/prost#661

The additional `#![allow(unknown_lints)]` had to be added as the
`derive_partial_eq_without_eq` is unknown by the `stable` and `beta`
toolchains.
