### PR TITLE
[RVPS] Implement a local file storage as Cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ Cargo.lock
 target
 
 users/
+
+# Local Fs tempfile
+reference_values

--- a/rvps/Cargo.toml
+++ b/rvps/Cargo.toml
@@ -15,6 +15,7 @@ chrono = { version = "0.4.19", features = [ "serde" ] }
 tempfile = "3.3.0"
 base64 = "0.13.0"
 log = "0.4.17"
+sled = "0.34.7"
 
 [dev-dependencies]
 testing_logger = "0.1.1"

--- a/rvps/src/store/local_fs/README.md
+++ b/rvps/src/store/local_fs/README.md
@@ -1,0 +1,17 @@
+# Local File System Storage
+
+This is a simple storage, which will store the
+Reference Values in a local file. Thus the data
+of the RVPS is persistent, and also safe when it
+comes to restart or crash.
+
+The underlying storage engine is `sled`, which
+has the most downloads on `crates.io` as key-value
+storage. Although it has now stopped updating
+for almost a year, it meets our needs to save/retrieve
+data on local file system.
+
+All the data will be stored in the directory `/opt/attestation-server/reference_values`.
+
+More about `sled` please refer to
+[git repo](https://github.com/spacejam/sled).

--- a/rvps/src/store/local_fs/mod.rs
+++ b/rvps/src/store/local_fs/mod.rs
@@ -1,0 +1,158 @@
+// Copyright (c) 2022 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+//! This Store stores RV information inside a local file
+
+use std::path::Path;
+
+use anyhow::*;
+
+use crate::{ReferenceValue, Store};
+
+/// Local directory path to store the reference values,
+/// which is created by sled engine.
+const FILE_PATH: &str = "/opt/attestation-server/reference_values";
+
+/// `LocalFs` implements [`Store`] trait. And
+/// it uses rocksdb inside.
+pub struct LocalFs {
+    engine: sled::Db,
+}
+
+impl Default for LocalFs {
+    /// Create a `LocalFs` storage, which will use path [`FILE_PATH`]
+    /// to store files.
+    fn default() -> Self {
+        let path = Path::new(FILE_PATH);
+        LocalFs::new(path).expect("Failed to create LocalFs Store.")
+    }
+}
+
+impl LocalFs {
+    /// Create a new [`LocalFs`] with given
+    /// file storage path.
+    fn new(path: &Path) -> Result<Self> {
+        let engine = sled::open(path)?;
+        Ok(Self { engine })
+    }
+}
+
+impl Store for LocalFs {
+    fn set(&mut self, name: String, rv: ReferenceValue) -> Result<Option<ReferenceValue>> {
+        let rv_serde = serde_json::to_vec(&rv)?;
+        let res = match self.engine.insert(name, rv_serde)? {
+            Some(v) => {
+                let v = serde_json::from_slice(&v)?;
+                Ok(Some(v))
+            }
+            None => Ok(None),
+        };
+
+        self.engine.flush()?;
+        res
+    }
+
+    fn get(&self, name: &str) -> Result<Option<ReferenceValue>> {
+        match self.engine.get(name)? {
+            Some(v) => {
+                let v = serde_json::from_slice(&v)?;
+                Ok(Some(v))
+            }
+            None => Ok(None),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serial_test::serial;
+
+    use crate::{store::local_fs::LocalFs, ReferenceValue, Store};
+
+    const KEY: &str = "test1";
+
+    /// This test will test the `set` and `get` interface
+    /// for [`LocalFs`].
+    #[test]
+    #[serial]
+    fn set_and_get() {
+        let temp_dir = tempfile::tempdir().expect("create tempdir failed");
+        {
+            let mut store = LocalFs::new(temp_dir.path()).expect("create local fs store failed.");
+            let rv = ReferenceValue::new().expect("create ReferenceValue failed.");
+            assert!(
+                store
+                    .set(KEY.to_owned(), rv.clone())
+                    .expect("set rv failed.")
+                    .is_none(),
+                "the storage has previous key of {}",
+                KEY
+            );
+            let got = store
+                .get(KEY)
+                .expect("get rv failed.")
+                .expect("get None from LocalFs Store");
+            assert_eq!(got, rv);
+        }
+    }
+
+    /// This test will test the `set` interface with the
+    /// duplicated key for [`LocalFs`].
+    #[test]
+    #[serial]
+    fn set_duplicated() {
+        let temp_dir = tempfile::tempdir().expect("create tempdir failed");
+        {
+            let mut store = LocalFs::new(temp_dir.path()).expect("create local fs store failed.");
+            let rv_old = ReferenceValue::new()
+                .expect("create ReferenceValue failed.")
+                .set_name("old");
+
+            let rv_new = ReferenceValue::new()
+                .expect("create ReferenceValue failed.")
+                .set_name("new");
+
+            assert!(
+                store
+                    .set(KEY.to_owned(), rv_old.clone())
+                    .expect("set rv failed.")
+                    .is_none(),
+                "the storage has previous key of {}",
+                KEY
+            );
+
+            let got = store
+                .set(KEY.to_owned(), rv_new)
+                .expect("get rv failed.")
+                .expect("get None from LocalFs Store");
+
+            assert_eq!(got, rv_old);
+        }
+    }
+
+    /// This test will simulate a restart operation
+    /// for [`LocalFs`].
+    #[test]
+    #[serial]
+    fn restart() {
+        let rv = ReferenceValue::new().expect("create ReferenceValue failed.");
+        let temp_dir = tempfile::tempdir().expect("create tempdir failed");
+        {
+            let mut store = LocalFs::new(temp_dir.path()).expect("create local fs store failed.");
+            store
+                .set(KEY.to_owned(), rv.clone())
+                .expect("set rv failed.");
+        }
+        {
+            let store =
+                LocalFs::new(temp_dir.path()).expect("read previous local fs store failed.");
+            let got = store
+                .get(KEY)
+                .expect("get rv failed.")
+                .expect("get None from LocalFs Store");
+            assert_eq!(got, rv);
+        }
+    }
+}

--- a/rvps/src/store/mod.rs
+++ b/rvps/src/store/mod.rs
@@ -9,13 +9,16 @@ use crate::reference_value::ReferenceValue;
 
 use anyhow::Result;
 
+pub mod local_fs;
+
 /// Interface of a `Store`.
 /// We only provide a simple instance here which implements
 /// Store. In more scenarios, RV should be stored in persistent
 /// storage, like database, file and so on. All of the mentioned
 /// forms will have the same interface as following.
 pub trait Store {
-    /// Store a reference value
+    /// Store a reference value. If the given `name` exists,
+    /// return the previous `Some<ReferenceValue>`, otherwise return `None`
     fn set(&mut self, name: String, rv: ReferenceValue) -> Result<Option<ReferenceValue>>;
 
     // Retrieve a reference value


### PR DESCRIPTION
Due to https://github.com/confidential-containers/attestation-service/issues/11, an implementation of local file storage as `Store` is added in this pr. 

#### Change Log

- Added local-fs storage using `sled` as engine.
- Added related document and interface tests of local-fs storage.
- All the data will be stored in the directory `/opt/attestation-server/reference_values`, where `/opt/attestation-server` is const `ATTESTATION_SERVER_WORKDIR ` in attestation-server.