### PR TITLE
fix: rename cache to store in RVPS

### DIFF
--- a/rvps/src/store/mod.rs
+++ b/rvps/src/store/mod.rs
@@ -3,18 +3,18 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-//! Cache is responsible for storing verified Reference Values
+//! Store is responsible for storing verified Reference Values
 
 use crate::reference_value::ReferenceValue;
 
 use anyhow::Result;
 
-/// Interface of a `Cache`.
+/// Interface of a `Store`.
 /// We only provide a simple instance here which implements
-/// Cache. In more scenarios, RV should be stored in persistent
+/// Store. In more scenarios, RV should be stored in persistent
 /// storage, like database, file and so on. All of the mentioned
 /// forms will have the same interface as following.
-pub trait Cache {
+pub trait Store {
     /// Store a reference value
     fn set(&mut self, name: String, rv: ReferenceValue) -> Result<Option<ReferenceValue>>;
 


### PR DESCRIPTION
#### Change Log

Rename the component `Cache` to `Store` in RVPS to avoid ambiguity