### PR TITLE
kbs-types sync

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ path = "bin/grpc-as/src/main.rs"
 [features]
 default = [ "in-toto" ]
 in-toto = []
+sample_verifier = []
 
 [dependencies]
 anyhow = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,8 @@ env_logger = "0.9.1"
 futures = "0.3.17"
 # TODO: Replace this with crate.io published version
 in-toto = { git = "https://github.com/Xynnn007/in-toto-rs.git", rev = "7f69799" }
+# TODO: Replace this with kbs-types next published version (0.2.0)
+kbs-types = { git = "https://github.com/virtee/kbs-types.git" }
 lazy_static = "1.4.0"
 log = "0.4.17"
 path-clean = "0.1.0"

--- a/bin/grpc-as/proto/attestation.proto
+++ b/bin/grpc-as/proto/attestation.proto
@@ -2,8 +2,15 @@ syntax = "proto3";
 
 package attestation;
 
+enum Tee {
+    SEV = 0;
+    SGX = 1;
+    SNP = 2;
+    TDX = 3;
+}
+
 message AttestationRequest {
-    string tee = 1;
+    Tee tee = 1;
     string nonce = 2;
     string evidence = 3;
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,46 +1,11 @@
-use crate::verifier::*;
-use anyhow::{anyhow, Result};
+use kbs_types::Tee;
 use serde::{Deserialize, Serialize};
 
 pub type TeeEvidenceParsedClaim = serde_json::Value;
 
-/// The supported TEE types:
-/// - Tdx: TDX TEE.
-/// - Sgx: SGX TEE.
-/// - SevSnp: SEV-SNP TEE.
-/// - Sample: A dummy TEE that used to test/demo the attestation service functionalities.
-#[derive(Debug, EnumString)]
-#[strum(ascii_case_insensitive)]
-pub enum TEE {
-    Tdx,
-    Sgx,
-    SevSnp,
-    Sample,
-}
-
-impl TEE {
-    #[allow(dead_code)]
-    pub fn to_verifier(&self) -> Result<Box<dyn Verifier + Send + Sync>> {
-        match self {
-            TEE::Sample => {
-                Ok(Box::<sample::Sample>::default() as Box<dyn Verifier + Send + Sync>)
-            }
-            _ => Err(anyhow!("TEE is not supported!")),
-        }
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-pub struct Attestation {
-    #[serde(rename = "tee-pubkey")]
-    pub tee_pubkey: String,
-    #[serde(rename = "tee-evidence")]
-    pub tee_evidence: String,
-}
-
 #[derive(Serialize, Deserialize, Debug)]
 pub struct AttestationResults {
-    tee: String,
+    tee: Tee,
     allow: bool,
     output: ResultOutput,
     tcb: Option<String>,
@@ -48,7 +13,7 @@ pub struct AttestationResults {
 
 impl AttestationResults {
     pub fn new(
-        tee: String,
+        tee: Tee,
         allow: bool,
         verifier_output: Option<String>,
         policy_engine_output: Option<String>,
@@ -69,8 +34,8 @@ impl AttestationResults {
         self.allow
     }
 
-    pub fn tee(&self) -> &str {
-        &self.tee
+    pub fn tee(&self) -> Tee {
+        self.tee.clone()
     }
 
     pub fn output(&self) -> &ResultOutput {

--- a/src/verifier/mod.rs
+++ b/src/verifier/mod.rs
@@ -1,8 +1,15 @@
-use crate::types::{Attestation, TeeEvidenceParsedClaim};
+use crate::types::TeeEvidenceParsedClaim;
 use anyhow::Result;
 use async_trait::async_trait;
+use kbs_types::{Attestation, Tee};
 
 pub mod sample;
+
+pub(crate) fn to_verifier(tee: &Tee) -> Result<Box<dyn Verifier + Send + Sync>> {
+    match tee {
+        Tee::Sev | Tee::Sgx | Tee::Snp | Tee::Tdx => todo!(),
+    }
+}
 
 #[async_trait]
 pub trait Verifier {

--- a/src/verifier/mod.rs
+++ b/src/verifier/mod.rs
@@ -5,6 +5,12 @@ use kbs_types::{Attestation, Tee};
 
 pub mod sample;
 
+#[cfg(feature = "sample_verifier")]
+pub(crate) fn to_verifier(_tee: &Tee) -> Result<Box<dyn Verifier + Send + Sync>> {
+    Ok(Box::new(sample::Sample::default()) as Box<dyn Verifier + Send + Sync>)
+}
+
+#[cfg(not(feature = "sample_verifier"))]
 pub(crate) fn to_verifier(tee: &Tee) -> Result<Box<dyn Verifier + Send + Sync>> {
     match tee {
         Tee::Sev | Tee::Sgx | Tee::Snp | Tee::Tdx => todo!(),

--- a/src/verifier/sample/mod.rs
+++ b/src/verifier/sample/mod.rs
@@ -32,7 +32,7 @@ impl Verifier for Sample {
 
         let mut hasher = Sha384::new();
         hasher.update(&nonce);
-        hasher.update(&attestation.tee_pubkey);
+        hasher.update(&attestation.tee_pubkey.k);
         let reference_report_data = base64::encode(hasher.finalize());
 
         verify_tee_evidence(reference_report_data, &attestation.tee_evidence)


### PR DESCRIPTION
This PR syncs with the[`kbs-types`](https://github.com/virtee/kbs-types) in order to have common KBS type definitions (`Tee`, `Attestation`) for both the AS and the KBS implementations.

One consequence of using the `kbs-types` crate is that we can no longer easily instantiate the `Sample` verifier. This PR puts it under a feature flag (`sample_verifier`). When turned on, the only available verifier is the `Sample` one. When turned off, `Sample` is not available.