### PR TITLE
AS: Fix a couple of clippy warnings

### DIFF
--- a/src/rvps/store/mod.rs
+++ b/src/rvps/store/mod.rs
@@ -23,7 +23,7 @@ impl StoreType {
     #[allow(dead_code)]
     pub fn to_store(&self) -> Result<Box<dyn Store + Send + Sync>> {
         match self {
-            StoreType::LocalFs => Ok(Box::new(LocalFs::default()) as Box<dyn Store + Send + Sync>),
+            StoreType::LocalFs => Ok(Box::<LocalFs>::default() as Box<dyn Store + Send + Sync>),
         }
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -23,7 +23,7 @@ impl TEE {
     pub fn to_verifier(&self) -> Result<Box<dyn Verifier + Send + Sync>> {
         match self {
             TEE::Sample => {
-                Ok(Box::new(sample::Sample::default()) as Box<dyn Verifier + Send + Sync>)
+                Ok(Box::<sample::Sample>::default() as Box<dyn Verifier + Send + Sync>)
             }
             _ => Err(anyhow!("TEE is not supported!")),
         }


### PR DESCRIPTION
Box::new(_) of default value can be simplified into Box::<_>::default(). See https://rust-lang.github.io/rust-clippy/master/index.html#box_default

Signed-off-by: Samuel Ortiz <sameo@rivosinc.com>