### PR TITLE
fix: Sample verifier branch arm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ path = "bin/grpc-as/src/main.rs"
 [features]
 default = [ "in-toto" ]
 in-toto = []
-sample_verifier = []
 
 [dependencies]
 anyhow = "1.0"
@@ -23,7 +22,7 @@ futures = "0.3.17"
 # TODO: Replace this with crate.io published version
 in-toto = { git = "https://github.com/Xynnn007/in-toto-rs.git", rev = "7f69799" }
 # TODO: Replace this with kbs-types next published version (0.2.0)
-kbs-types = { git = "https://github.com/virtee/kbs-types.git" }
+kbs-types = { git = "https://github.com/virtee/kbs-types.git", rev = "50ec211" }
 lazy_static = "1.4.0"
 log = "0.4.17"
 path-clean = "0.1.0"

--- a/src/verifier/mod.rs
+++ b/src/verifier/mod.rs
@@ -5,15 +5,10 @@ use kbs_types::{Attestation, Tee};
 
 pub mod sample;
 
-#[cfg(feature = "sample_verifier")]
-pub(crate) fn to_verifier(_tee: &Tee) -> Result<Box<dyn Verifier + Send + Sync>> {
-    Ok(Box::new(sample::Sample::default()) as Box<dyn Verifier + Send + Sync>)
-}
-
-#[cfg(not(feature = "sample_verifier"))]
 pub(crate) fn to_verifier(tee: &Tee) -> Result<Box<dyn Verifier + Send + Sync>> {
     match tee {
         Tee::Sev | Tee::Sgx | Tee::Snp | Tee::Tdx => todo!(),
+        Tee::Sample => Ok(Box::<sample::Sample>::default() as Box<dyn Verifier + Send + Sync>),
     }
 }
 


### PR DESCRIPTION
Upstream `kbs-types` has updated a new test type `Sample`, thus the branch arm need to add the new type to pass the syntax check.

Related to https://github.com/confidential-containers/attestation-service/pull/47