### PR TITLE
Fix `make` && `make install` in the top dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,3 +25,6 @@ install:
 	for bin_name in $(BIN_NAMES); do \
 		install -D -m0755 $(TARGET_DIR)/$$bin_name $(DESTDIR); \
 	done
+
+clean:
+	cargo clean

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,10 @@ else
     TARGET_DIR := $(TARGET_DIR)/release
 endif
 
-build:
-	cargo build $(release)
+build: grpc-as
+
+grpc-as:
+	cargo build --bin grpc-as --features rvps-server,rvps-proxy,tokio/rt-multi-thread $(release)
 
 install:
 	for bin_name in $(BIN_NAMES); do \

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ TOP_DIR := .
 CUR_DIR := $(shell pwd)
 PREFIX := /usr/local
 TARGET_DIR := target
-BIN_NAMES := grpc-as grpc-as-ctl
+BIN_NAMES := grpc-as
 
 DEBUG ?=
 DESTDIR ?= $(PREFIX)/bin

--- a/bin/grpc-as/src/server.rs
+++ b/bin/grpc-as/src/server.rs
@@ -8,9 +8,7 @@ use tonic::{Request, Response, Status};
 use crate::as_api::attestation_service_server::{AttestationService, AttestationServiceServer};
 use crate::as_api::{AttestationRequest, AttestationResponse, Tee as GrpcTee};
 
-use crate::rvps_api::reference_value_provider_service_server::{
-    ReferenceValueProviderService, ReferenceValueProviderServiceServer,
-};
+use crate::rvps_api::reference_value_provider_service_server::ReferenceValueProviderService;
 
 use crate::rvps_api::{
     ReferenceValueQueryRequest, ReferenceValueQueryResponse, ReferenceValueRegisterRequest,
@@ -94,9 +92,8 @@ impl ReferenceValueProviderService for AttestationServer {
         &self,
         _request: Request<ReferenceValueQueryRequest>,
     ) -> Result<Response<ReferenceValueQueryResponse>, Status> {
-        let status = Status::aborted(format!(
-            "Cannot query reference values using RVPS as a submodule in AS."
-        ));
+        let status =
+            Status::aborted("Cannot query reference values using RVPS as a submodule in AS.");
 
         Err(status)
     }


### PR DESCRIPTION
It was:

> for bin_name in grpc-as grpc-as-ctl; do \
        install -D -m0755 target/release/$bin_name /usr/local/bin; \
done
install: cannot stat 'target/release/grpc-as': No such file or directory
install: cannot stat 'target/release/grpc-as-ctl': No such file or directory
Makefile:23: recipe for target 'install' failed


Now it should be okay,

>    Compiling attestation-service v0.1.0 (/home/dave/tmp/attestation-service)
    Finished release [optimized] target(s) in 1m 58s
for bin_name in grpc-as; do \
        install -D -m0755 target/release/$bin_name /usr/local/bin; \
done