### PR TITLE
Update kbs-types to v0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ hex = "0.4.3"
 in-toto = { git = "https://github.com/Xynnn007/in-toto-rs.git", rev = "7f69799", optional = true }
 intel-tee-quote-verification-rs = { version = "0.2.1", optional = true }
 # TODO: Replace this with kbs-types next published version (0.2.0)
-kbs-types = { git = "https://github.com/virtee/kbs-types.git", rev = "13b9378f" }
+kbs-types = "0.2"
 lazy_static = "1.4.0"
 log = "0.4.17"
 path-clean = "0.1.0"

--- a/as-types/Cargo.toml
+++ b/as-types/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-kbs-types = { git = "https://github.com/virtee/kbs-types.git", rev = "13b9378f" }
+kbs-types = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "*"

--- a/src/verifier/sample/mod.rs
+++ b/src/verifier/sample/mod.rs
@@ -28,7 +28,8 @@ impl Verifier for Sample {
 
         let mut hasher = Sha384::new();
         hasher.update(&nonce);
-        hasher.update(&attestation.tee_pubkey.k);
+        hasher.update(&attestation.tee_pubkey.k_mod);
+        hasher.update(&attestation.tee_pubkey.k_exp);
         let reference_report_data = base64::encode(hasher.finalize());
 
         verify_tee_evidence(reference_report_data, &attestation.tee_evidence)

--- a/src/verifier/tdx/mod.rs
+++ b/src/verifier/tdx/mod.rs
@@ -38,7 +38,8 @@ impl Verifier for Tdx {
 
         let mut hasher = Sha384::new();
         hasher.update(&nonce);
-        hasher.update(&attestation.tee_pubkey.k);
+        hasher.update(&attestation.tee_pubkey.k_mod);
+        hasher.update(&attestation.tee_pubkey.k_exp);
         let mut hash_of_nonce_pubkey = hasher.finalize().to_vec();
         hash_of_nonce_pubkey.extend([0; 16]);
 


### PR DESCRIPTION
The pubkey logic needs to be adjusted to match the upstream virtee/kbs-types structs. The fix needs to be coupled with the respective PRs on [Attestation Agent](https://github.com/confidential-containers/attestation-agent/pull/170) and [KBS](https://github.com/confidential-containers/attestation-agent/pull/170).

fixes #77 