### PR TITLE
Fix for pointer type error

### DIFF
--- a/src/policy_engine/opa/mod.rs
+++ b/src/policy_engine/opa/mod.rs
@@ -56,19 +56,19 @@ impl PolicyEngine for OPA {
             .map_err(|e| anyhow!("Read OPA policy file failed: {:?}", e))?;
 
         let policy_go = GoString {
-            p: policy.as_ptr() as *const i8,
+            p: policy.as_ptr() as *const c_char,
             n: policy.len() as isize,
         };
 
         let reference = serde_json::json!({ "reference": reference_data_map }).to_string();
 
         let reference_go = GoString {
-            p: reference.as_ptr() as *const i8,
+            p: reference.as_ptr() as *const c_char,
             n: reference.len() as isize,
         };
 
         let input_go = GoString {
-            p: input.as_ptr() as *const i8,
+            p: input.as_ptr() as *const c_char,
             n: input.len() as isize,
         };
 


### PR DESCRIPTION
Pointer type conversion fails on s390x [here](https://github.com/confidential-containers/attestation-service/blob/0f7a70e98fc14890f2842dc66222b55ff28e1d99/src/policy_engine/opa/mod.rs#L59). This is a [known issue](https://github.com/rust-lang/rust/issues/60226) in rust and not specific to s390x. The best practice to fix this issue is to use `c_char` instead of `i8/u8` like [this](https://github.com/phanikishoreg/llvm-rs/commit/013d1e95406264df57879cda698dbe7a806b62b7).