### PR TITLE
TDX | Update CCEL parse logic to support both TDVF and TD-Shim

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ required-features = [ "rvps-native", "rvps-grpc", "tokio/rt-multi-thread" ]
 [features]
 default = [ "rvps-native", "in-toto", "all-verifier" ]
 all-verifier = [ "tdx-verifier" ]
-tdx-verifier = [ "cc-measurement", "scroll", "intel-tee-quote-verification-rs" ]
+tdx-verifier = [ "eventlog-rs", "scroll", "intel-tee-quote-verification-rs" ]
 
 rvps-native = []
 rvps-grpc = [ "tonic" ]
@@ -29,11 +29,11 @@ async-trait = "0.1.31"
 as-types = { path = "./as-types" }
 base64 = "0.13.0"
 byteorder = "1"
-cc-measurement = { git = "https://github.com/confidential-containers/td-shim", optional = true }
 cfg-if = "1.0.0"
 chrono = { version = "0.4.19", features = [ "serde" ] }
 clap = { version = "3.2.6", features = ["derive"] }
 env_logger = "0.9.1"
+eventlog-rs = { version = "0.1.3", optional = true }
 futures = "0.3.17"
 hex = "0.4.3"
 # TODO: Replace this with crate.io published version


### PR DESCRIPTION
This change updates the parsing method of TDX CCEL, The TD SHIM specific cc-measurement library is no longer used, Use the eventlog-rs library instead to support CCEL generated by both TDVF and TD SHIM.

cc @Xynnn007 