### PR TITLE
Readd az-snp-vtpm verifier

### DIFF
--- a/attestation-service/Cargo.toml
+++ b/attestation-service/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [features]
 default = [ "rvps-native", "all-verifier" ]
-all-verifier = [ "tdx-verifier", "sgx-verifier", "snp-verifier" ]
+all-verifier = [ "tdx-verifier", "sgx-verifier", "snp-verifier", "az-snp-vtpm-verifier" ]
 tdx-verifier = [ "eventlog-rs", "scroll", "intel-tee-quote-verification-rs" ]
 sgx-verifier = [ "scroll", "intel-tee-quote-verification-rs" ]
 az-snp-vtpm-verifier = [ "az-snp-vtpm", "sev" ]

--- a/attestation-service/src/policy_engine/opa/mod.rs
+++ b/attestation-service/src/policy_engine/opa/mod.rs
@@ -177,7 +177,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_set_policy() {
-        let mut opa = OPA::new(PathBuf::from("./test_data")).unwrap();
+        let mut opa = OPA::new(PathBuf::from("../test_data")).unwrap();
         let policy = "package policy
 default allow = true"
             .to_string();

--- a/attestation-service/src/verifier/az_snp_vtpm/mod.rs
+++ b/attestation-service/src/verifier/az_snp_vtpm/mod.rs
@@ -143,9 +143,9 @@ mod tests {
 
     #[test]
     fn test_verify_snp_report() {
-        let report = include_bytes!("../../test_data/az-hcl-data.bin");
+        let report = include_bytes!("../../../../test_data/az-hcl-data.bin");
         let hcl_data: HclData = report.as_slice().try_into().unwrap();
-        let vcek = Vcek::from_pem(include_str!("../../test_data/az-vcek.pem")).unwrap();
+        let vcek = Vcek::from_pem(include_str!("../../../../test_data/az-vcek.pem")).unwrap();
         verify_snp_report(hcl_data.report().snp_report(), &vcek).unwrap();
 
         let mut wrong_report = *report;
@@ -157,10 +157,10 @@ mod tests {
 
     #[test]
     fn test_verify_quote() {
-        let signature = include_bytes!("../../test_data/az-vtpm-quote-sig.bin").to_vec();
-        let message = include_bytes!("../../test_data/az-vtpm-quote-msg.bin").to_vec();
+        let signature = include_bytes!("../../../../test_data/az-vtpm-quote-sig.bin").to_vec();
+        let message = include_bytes!("../../../../test_data/az-vtpm-quote-msg.bin").to_vec();
         let quote = Quote { signature, message };
-        let report = include_bytes!("../../test_data/az-hcl-data.bin");
+        let report = include_bytes!("../../../../test_data/az-hcl-data.bin");
         let hcl_data: HclData = report.as_slice().try_into().unwrap();
         let nonce = "challenge".as_bytes();
         verify_quote(&quote, &hcl_data, nonce).unwrap();
@@ -186,7 +186,7 @@ mod tests {
 
     #[test]
     fn test_parse_evidence() {
-        let report = include_bytes!("../../test_data/az-hcl-data.bin");
+        let report = include_bytes!("../../../../test_data/az-hcl-data.bin");
         let hcl_data: HclData = report.as_slice().try_into().unwrap();
         let snp_report = hcl_data.report().snp_report();
         let claim = parse_tee_evidence(snp_report);


### PR DESCRIPTION
Readded the az-snp-vtpm verifier to the default verifiers, so it will get built in kbs, also adjusted the paths that have been used in the tests to match the refactoring.

fixes #102 