### PR TITLE
Dockerfile: Copy TPM runtime dependencies

### DIFF
--- a/Dockerfile.as
+++ b/Dockerfile.as
@@ -14,14 +14,14 @@ RUN wget https://go.dev/dl/go1.20.1.linux-amd64.tar.gz && \
 ENV PATH="/usr/local/go/bin:${PATH}"
 
 # Install TPM Build Dependencies
-RUN apt-get update && apt install -y protobuf-compiler clang libtss2-dev
+RUN apt-get update && apt-get install -y protobuf-compiler clang libtss2-dev
 
 # Install TDX Build Dependencies
 RUN curl -L https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | tee intel-sgx-deb.key | apt-key add - && \
     echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu focal main' | tee /etc/apt/sources.list.d/intel-sgx.list && \
     apt-get update && apt-get install -y libtdx-attest-dev libsgx-dcap-quote-verify-dev
 
-# Build and Instll gRPC attestation-service
+# Build and Install gRPC attestation-service
 RUN cargo install --path bin/grpc-as
 
 
@@ -38,6 +38,9 @@ RUN curl -L https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key 
     apt-get update && \
     apt-get install -y libsgx-dcap-default-qpl libsgx-dcap-quote-verify && \
     rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
+
+# Copy TPM Runtime Dependencies
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libtss* /usr/lib/x86_64-linux-gnu
 
 COPY --from=builder /usr/local/cargo/bin/grpc-as /usr/local/bin/grpc-as
 


### PR DESCRIPTION
TPM libraries installed during first build in Dockerfile are not available at runtime.

`apt-get install libtss2-dev` will install libraries in `/usr/lib/x86_64-linux-gnu` that the Rust executable needs to load. However, this step happens only during the stage in the build to create the Rust executable. We need to copy these dependencies to the final half of the build so the executable can find them.

Confirmed that the gRPC server now starts with a locally built image
```
[2023-06-22T18:51:20Z INFO  grpc_as::server] Listen socket: 0.0.0.0:50004
[2023-06-22T18:51:20Z INFO  grpc_as::server] Start a local RVPS (Server mode)
```

Fixes https://github.com/confidential-containers/attestation-service/issues/113