### PR TITLE
deps: update kbs-types to 0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1357,9 +1357,9 @@ dependencies = [
 
 [[package]]
 name = "kbs-types"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5b2b89d8b831b80f2f2ef164e08ef109d2e60a04e43b06dd85d465fc0c9b6ee"
+checksum = "9844a35cb1eaa52d9527f7eb062ce0be35a46080655997c3357db7231ded9b7c"
 dependencies = [
  "serde",
  "serde_json",

--- a/as-types/Cargo.toml
+++ b/as-types/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-kbs-types = "0.3"
+kbs-types = "0.4"
 serde.workspace = true
 serde_json.workspace = true

--- a/attestation-service/Cargo.toml
+++ b/attestation-service/Cargo.toml
@@ -20,7 +20,7 @@ asn1-rs = { version = "0.5.1", optional = true }
 async-trait.workspace = true
 as-types = { path = "../as-types" }
 az-snp-vtpm = { git = "https://github.com/kinvolk/azure-cvm-tooling", rev = "2c2e411", default-features = false, features = ["verifier"], optional = true }
-base64 = "0.21.2"
+base64 = "0.21"
 bincode = "1.3.3"
 byteorder = "1"
 cfg-if = "1.0.0"

--- a/attestation-service/Cargo.toml
+++ b/attestation-service/Cargo.toml
@@ -29,7 +29,7 @@ eventlog-rs = { version = "0.1.3", optional = true }
 futures = "0.3.17"
 hex = "0.4.3"
 sgx-dcap-quoteverify-rs = { git = "https://github.com/intel/SGXDataCenterAttestationPrimitives", tag = "DCAP_1.16", optional = true }
-kbs-types = "0.3"
+kbs-types = "0.4"
 lazy_static = "1.4.0"
 log.workspace = true
 openssl = { version = "0.10.43", optional = true }


### PR DESCRIPTION
Preparing to upgrade KBS to `kbs-types 0.4`.

There is also a relaxation of `base64 0.21.2` to `base64 0.21` required, as KBS uses `jsonwebtoken`, which requires `base64 ^0.21.0`.