### PR TITLE
dockerfile: update the builder image to rust:latest

### DIFF
--- a/Dockerfile.as
+++ b/Dockerfile.as
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM rust:1.67 as builder
+FROM rust:latest as builder
 
 WORKDIR /usr/src/attestation-service
 COPY . .

--- a/Dockerfile.rvps
+++ b/Dockerfile.rvps
@@ -2,7 +2,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-FROM rust:1.67 as builder
+FROM rust:latest as builder
 
 WORKDIR /usr/src/rvps
 


### PR DESCRIPTION
rust:1.67 cannot build half v2.3.1 in CCA's PR
https://github.com/confidential-containers/attestation-service/actions/runs/5830448221/job/15811842602?pr=90

latest will choose the latest version of rust image to be the builder

helps https://github.com/confidential-containers/attestation-service/pull/90

cc @chendave @jialez0 