### PR TITLE
Update `az-snp-vtpm` version to avoid vendor openssl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,7 +316,7 @@ dependencies = [
 [[package]]
 name = "az-snp-vtpm"
 version = "0.2.3"
-source = "git+https://github.com/kinvolk/azure-cvm-tooling?rev=2c2e411#2c2e411dfb6f64fb4ffa4443213c5777de7af30d"
+source = "git+https://github.com/kinvolk/azure-cvm-tooling?rev=09a8a0d#09a8a0d4a0c6347234de392064215037b09a1d0c"
 dependencies = [
  "bincode",
  "clap 4.3.21",
@@ -717,7 +717,7 @@ dependencies = [
 [[package]]
 name = "csv-rs"
 version = "0.1.0"
-source = "git+https://gitee.com/anolis/csv-rs?rev=8a90aac#8a90aac07d9039425d29358383a822bc86fc15b7"
+source = "git+https://gitee.com/anolis/csv-rs?rev=bcf3bcc#bcf3bcc0ae5b3d0e42d6d91c004e582d9b1c90fd"
 dependencies = [
  "bitfield",
  "codicon",
@@ -1834,15 +1834,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
-name = "openssl-src"
-version = "111.27.0+1.1.1v"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06e8f197c82d7511c5b014030c9b1efeda40d7d5f99d23b4ceed3524a5e63f02"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "openssl-sys"
 version = "0.9.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1850,7 +1841,6 @@ checksum = "866b5f16f90776b9bb8dc1e1802ac6f0513de3a7a7465867bfbc563dc737faac"
 dependencies = [
  "cc",
  "libc",
- "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/attestation-service/Cargo.toml
+++ b/attestation-service/Cargo.toml
@@ -20,7 +20,7 @@ anyhow.workspace = true
 asn1-rs = { version = "0.5.1", optional = true }
 async-trait.workspace = true
 as-types = { path = "../as-types" }
-az-snp-vtpm = { git = "https://github.com/kinvolk/azure-cvm-tooling", rev = "2c2e411", default-features = false, features = ["verifier"], optional = true }
+az-snp-vtpm = { git = "https://github.com/kinvolk/azure-cvm-tooling", rev = "09a8a0d", default-features = false, features = ["verifier"], optional = true }
 base64 = "0.21"
 bincode = "1.3.3"
 byteorder = "1"


### PR DESCRIPTION
https://github.com/kinvolk/azure-cvm-tooling/commit/09a8a0d4a0c6347234de392064215037b09a1d0c