### PR TITLE
as: Update csv-rs dep to rev 05fbacd.

### DIFF
--- a/attestation-service/Cargo.toml
+++ b/attestation-service/Cargo.toml
@@ -30,7 +30,7 @@ cfg-if = "1.0.0"
 chrono = { version = "0.4.19", features = [ "serde" ] }
 codicon = { version = "3.0", optional = true }
 # TODO: change it to "0.1", once released.
-csv-rs = { git = "https://gitee.com/anolis/csv-rs", rev = "bcf3bcc", optional = true }
+csv-rs = { git = "https://gitee.com/anolis/csv-rs", rev = "05fbacd", optional = true }
 eventlog-rs = { version = "0.1.3", optional = true }
 futures = "0.3.17"
 hex = "0.4.3"


### PR DESCRIPTION
The new version of csv-rs will support openssl 3.1.x.
Maybe there is same issue such as AA: https://github.com/confidential-containers/guest-components/issues/346