### PR TITLE
Update az-snp-vtpm dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -317,8 +317,9 @@ dependencies = [
 
 [[package]]
 name = "az-snp-vtpm"
-version = "0.2.3"
-source = "git+https://github.com/kinvolk/azure-cvm-tooling?rev=09a8a0d#09a8a0d4a0c6347234de392064215037b09a1d0c"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecd961e70ecc38d342942ffb3c6d963a68a871aae23faa3ab8199e3ca1bca8c6"
 dependencies = [
  "bincode",
  "clap 4.3.23",
@@ -753,7 +754,7 @@ dependencies = [
 [[package]]
 name = "csv-rs"
 version = "0.1.0"
-source = "git+https://gitee.com/anolis/csv-rs?rev=bcf3bcc#bcf3bcc0ae5b3d0e42d6d91c004e582d9b1c90fd"
+source = "git+https://gitee.com/anolis/csv-rs?rev=05fbacd#05fbacd8ffff3d48bb19319da1c9a84b763d9302"
 dependencies = [
  "bitfield",
  "codicon",

--- a/attestation-service/Cargo.toml
+++ b/attestation-service/Cargo.toml
@@ -21,7 +21,7 @@ anyhow.workspace = true
 asn1-rs = { version = "0.5.1", optional = true }
 async-trait.workspace = true
 as-types = { path = "../as-types" }
-az-snp-vtpm = { git = "https://github.com/kinvolk/azure-cvm-tooling", rev = "09a8a0d", default-features = false, features = ["verifier"], optional = true }
+az-snp-vtpm = { version = "0.3.0", default-features = false, features = ["verifier"], optional = true }
 base64 = "0.21"
 bincode = "1.3.3"
 byteorder = "1"

--- a/attestation-service/src/verifier/az_snp_vtpm/mod.rs
+++ b/attestation-service/src/verifier/az_snp_vtpm/mod.rs
@@ -7,7 +7,7 @@ use super::{Attestation, TeeEvidenceParsedClaim, Verifier};
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use az_snp_vtpm::certs::{AmdChain, Vcek, X509};
-use az_snp_vtpm::hcl::{HclData, RuntimeData};
+use az_snp_vtpm::hcl::HclData;
 use az_snp_vtpm::report::Validateable;
 use az_snp_vtpm::vtpm::{Quote, VerifyVTpmQuote};
 use base64::Engine;
@@ -57,8 +57,7 @@ impl Verifier for AzSnpVtpm {
 }
 
 fn verify_quote(quote: &Quote, hcl_data: &HclData, hashed_nonce: &[u8]) -> Result<()> {
-    let runtime_data: RuntimeData = hcl_data.var_data().try_into()?;
-    let ak_pub = runtime_data.get_attestation_key()?;
+    let ak_pub = hcl_data.var_data().ak_pub()?;
 
     ak_pub
         .verify_quote(quote, hashed_nonce)


### PR DESCRIPTION
Azure rolled out a change in the HCL data structures, that'll break the current parsing logic of an az-snp-vtpm evidence.  Hence the bump to an update az-snp-vtpm crate, which accomodates this change.