### PR TITLE
Update Docker base image version and install openssl

### DIFF
--- a/Dockerfile.as
+++ b/Dockerfile.as
@@ -25,12 +25,12 @@ RUN curl -L https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key 
 RUN cargo install --path bin/grpc-as
 
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 LABEL org.opencontainers.image.source="https://github.com/confidential-containers/attestation-service"
 
 # Install TDX Runtime Dependencies
-RUN apt-get update && apt-get install curl gnupg -y && \
+RUN apt-get update && apt-get install curl gnupg openssl -y && \
     rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
 
 RUN curl -L https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | tee intel-sgx-deb.key | apt-key add - && \


### PR DESCRIPTION
Now we use ubuntu 20.04 as base image, the openssl version is 1.1.1 where the location of `libssl.so` is different from version 3.0+ and `csv-rs` crate now can only find `libssl.so` with version 3.0+